### PR TITLE
Fix sorting of times in Chrome cf issue #1

### DIFF
--- a/citutors.html
+++ b/citutors.html
@@ -378,6 +378,17 @@
         return t1Num == t2Num;
       }
 
+      // Takes two strings in format hh[:mm] and returns -1 if t1 < t2, 0 if equal, and 1 if greater than
+      function timeCompare(t1, t2) {
+        if (timeGreaterThan(t1, t2)) {
+          return 1;
+        }
+        else if (timeLessThan(t1, t2)) {
+          return -1;
+        }
+        return 0;
+      }
+
       // Takes a time and makes it pretty in 12 hour ("10" -> "10 AM")
       // Specifically makes all times < 10 into PM times
       function prettyTime(tstr) {
@@ -438,7 +449,7 @@
         // This way we can quickly update the table visuals for each available tutor
         let timeTable = new Object();
         // Start by ordering the times correctly
-        let orderedTimes = Object.keys(tutorTimes).sort(timeGreaterThan);
+        let orderedTimes = Object.keys(tutorTimes).sort(timeCompare);
         // All times before 10 are actually PM times, so we need to move those after
         let startAM = orderedTimes.findIndex(e => !timeLessThan(e, "10"));
         orderedTimes = orderedTimes.slice(startAM).concat(orderedTimes.slice(0, startAM));


### PR DESCRIPTION
Fix times not sorting correctly in Chromium browsers. Closes #1 

The problem here is that the function `fn` given to `Array.sort(fn)` is supposed to return one of three values depending on if one value is less than, equal to, or greater than the second value.  I did not realize this and was returning a boolean value for "is greater or is not greater" which happens to work perfectly well in Mozilla based browsers, but not Chromium ones.